### PR TITLE
Revise tandy plugin's prefix config

### DIFF
--- a/lib/plugins/tandy.js
+++ b/lib/plugins/tandy.js
@@ -2,14 +2,15 @@
 
 // Leaving empty leads to default (requiring module by file name to set as registered plugin)
 // module.exports = {};
-module.exports = {
+module.exports = (server, options) => ({
     plugins: {
         options: {
             actAsUser: true,
             userIdProperty: 'userId',//as it's going to appear in the jwt
             userUrlPrefix: '/user',
             userModel: 'users',
-            prefix: process.env.API_PREFIX
+            // Ensures tandy is synchronized with our plugin's route prefix or main plugin option, if any
+            prefix: server.realm.modifiers.route.prefix || options.apiPrefix
         }
     }
-};
+});


### PR DESCRIPTION
Heyo! small change to the tandy plugin config to separate it from the server while still ensuring its consistent with any global route prefix set for the plugin

hope it helps 🙏 