### PR TITLE
Check if password exists before continuing login

### DIFF
--- a/lib/routes/users-login.js
+++ b/lib/routes/users-login.js
@@ -31,10 +31,10 @@ module.exports = (server, options) => {
             const { Tokens, Users } = request.models();
             const Payload = request.payload;
 
-            const foundUser = await Users.query() .where({ email: Payload.email }).first();
+            const foundUser = await Users.query().where({ email: Payload.email }).whereNotNull('password').first();
 
             // User password gets set to null when using reset password route
-            if (!foundUser || !foundUser.password) {
+            if (!foundUser) {
                 return Boom.unauthorized('User or Password is invalid');
             }
 

--- a/lib/routes/users-login.js
+++ b/lib/routes/users-login.js
@@ -33,7 +33,8 @@ module.exports = (server, options) => {
 
             const foundUser = await Users.query() .where({ email: Payload.email }).first();
 
-            if (!foundUser) {
+            // User password gets set to null when using reset password route
+            if (!foundUser || !foundUser.password) {
                 return Boom.unauthorized('User or Password is invalid');
             }
 

--- a/lib/routes/users-login.js
+++ b/lib/routes/users-login.js
@@ -33,7 +33,6 @@ module.exports = (server, options) => {
 
             const foundUser = await Users.query().where({ email: Payload.email }).whereNotNull('password').first();
 
-            // User password gets set to null when using reset password route
             if (!foundUser) {
                 return Boom.unauthorized('User or Password is invalid');
             }


### PR DESCRIPTION
User password gets set to null when using reset password route, if we don't return early in the `user-login` route, it hard crashes